### PR TITLE
Adjust version in bower.json to match package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "srcdoc-polyfill",
   "main": "srcdoc-polyfill.js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/jugglinmike/srcdoc-polyfill",
   "authors": [
     "Mike Pennisi <mike@mikepennisi.com>"


### PR DESCRIPTION
The version mismatch leads to errors when using bower:

```
$ bower install --save srcdoc-polyfill
bower srcdoc-polyfill#*     not-cached git://github.com/jugglinmike/srcdoc-polyfill.git#*
bower srcdoc-polyfill#*        resolve git://github.com/jugglinmike/srcdoc-polyfill.git#*
bower srcdoc-polyfill#*       download https://github.com/jugglinmike/srcdoc-polyfill/archive/v0.2.0.tar.gz
bower srcdoc-polyfill#*        extract archive.tar.gz
bower srcdoc-polyfill#*       mismatch Version declared in the json (0.1.1) is different than the resolved one (0.2.0)
bower srcdoc-polyfill#*       resolved git://github.com/jugglinmike/srcdoc-polyfill.git#0.2.0
bower srcdoc-polyfill#~0.2.0   install srcdoc-polyfill#0.2.0
```

I'm pretty sure just changing it here will not help directly, but there should also be a new release with matching versions in `bower.json` and `package.json`
